### PR TITLE
Add -IncludePrelease to package manager console setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This theme is available as a pre-release on [NuGet](https://www.nuget.org/packag
 ### Package Manager Console
 
 ```
-PM> Install-Package Moov2.OrchardCore.BlogTheme
+PM> Install-Package Moov2.OrchardCore.BlogTheme -IncludePrerelease
 ```
 
 ### .NET CLI Console


### PR DESCRIPTION
Package manager console set up command fails to find NuGet package when `-IncludePrerelease` flag isn't included in the command.